### PR TITLE
Sökområde: Göteborg

### DIFF
--- a/index.php
+++ b/index.php
@@ -63,8 +63,10 @@
         function getAddress(search, startOrEnd){
             var request = new XMLHttpRequest();
 
-            request.open('GET', 'https://api.openrouteservice.org/geocode/autocomplete?api_key=5b3ce3597851110001cf6248e38d3f64310c46ceb044c9b37ef563cd&text='+search+'&boundary.country=SE&sources=openstreetmap&layers=neighbourhood,address,venue');
-
+            autocompletePart1= 'https://api.openrouteservice.org/geocode/autocomplete?api_key=5b3ce3597851110001cf6248e38d3f64310c46ceb044c9b37ef563cd&text=';
+            autocompletePart2= '&boundary.country=SE&sources=openstreetmap&layers=neighbourhood,address,venue'
+            autocompletePart3 = '&boundary.circle.lon=11.97307942&boundary.circle.lat=57.70914870&boundary.circle.radius=11';
+            request.open('GET', autocompletePart1 +search+ autocompletePart2 + autocompletePart3);
             request.setRequestHeader('Accept', 'application/json, application/geo+json, application/gpx+xml, img/png; charset=utf-8');
 
             request.onreadystatechange = function () {


### PR DESCRIPTION
Now there's a circular available search area for Gothenburg only. Aka you will only get (and be able to choose) gothenburg (or close area) addresses.
The mid point cordinate is Göteborg C and at the moment the circle radius is 11 km. That is enough to for example reach Partille, but not Landvetter.

Also devided the text string up in shorter sections to make the code line shorter and easier to read.

Tested by trying to input addresses outside the circular area, and then it could not find the addresses. Also if we now for example typ in "Stockholm" only gothenburg addresses show up, like "Stockholmsgatan, Göteborg, VG" etc.